### PR TITLE
Add analyze

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,6 @@ declaration   : origin
               | root-matches-origin
               | license
               | license-file
-              | potential-license-conflicts
               | root
               | files
               | name
@@ -445,19 +444,6 @@ The path to the license file relative to the `root` declaration.
 
 * type: `filepath | null`
 * default: `null`
-
-
-potential-license-conflicts
----
-
-When there is concern a dependency's license may introduce licensing conflicts, add its
-root directory to the `potential-license-conflicts` declaration. Doing so tells
-CodeBOM's `verify` command not to produce an error when it detects the same potential
-for conflicts. If the conflict is not in a development dependency (or `--source-distribution`
-is added), the `graph` command will highlight potential conflicts in red.
-
-* type: `[filepath]`
-* default: `[]`
 
 
 root

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ usage: codebom [-h] [--version] [-f FILE] {scan,verify,graph} ...
 Validate a Bill of Materials
 
 positional arguments:
-  {scan,verify,graph}
-    scan                Scan for missing declarations
-    verify              Verify declarations are consistent
+  {scan,verify,analyze,graph}
+    scan                Scan the codebase for missing declarations
+    verify              Verify declarations are consistent with the codebase
+    analyze             Analyze potential implications of the declarations
     graph               Graph license dependencies
 
 optional arguments:
@@ -305,6 +306,24 @@ optional arguments:
   --source-distribution
   -o FILE
   --check-origins {uri,contents}
+```
+
+codebom analyze
+---
+
+The `analyze` command attempts to report the implications of the BOM's
+declarations. For instance, if a project depends on another with a
+more restrictive license and no licensees are declared, it will
+output a message telling you there may be license conflict. The
+`analyze` command is the textual counterpart to the `graph` command.
+
+```
+usage: codebom analyze [-h] [--source-distribution] [-o FILE]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --source-distribution
+  -o FILE
 ```
 
 codebom graph

--- a/bin/codebom
+++ b/bin/codebom
@@ -6,6 +6,7 @@ from codebom.bom import BomError
 from codebom.lint import load_linted_bom
 from codebom.verify import verify_bom
 from codebom.scan import scan_bom
+from codebom.analyze import analyze_bom
 from codebom.graph import graph_bom
 from ruamel import yaml
 import os.path
@@ -63,6 +64,13 @@ if __name__ == '__main__':
             if args.add:
                 args.o.write(yaml.dump(data, Dumper=yaml.RoundTripDumper))
                 args.o.close()
+        elif args.command == 'analyze':
+            is_source_dist = args.source_distribution
+            messages = analyze_bom(bom, is_source_dist=is_source_dist)
+            if messages:
+                args.o.write('\n'.join(messages))
+                args.o.write('\n')
+            args.o.close()
         elif args.command == 'graph':
             is_source_dist = args.source_distribution
             dot = graph_bom(bom, is_source_dist=is_source_dist)

--- a/codebom/analyze.py
+++ b/codebom/analyze.py
@@ -5,16 +5,12 @@ def collect_license_warnings(bom, is_source_dist):
     warnings = []
     license_id = bom.license or 'Unknown'
 
-    known_conflicts = bom.potential_license_conflicts
     deps = is_source_dist and bom.all_dependencies or bom.dependencies
     for dep in deps:
         warnings += collect_license_warnings(dep, is_source_dist)
 
         dep_license_id = dep.license or 'Unknown'
         if not is_dependent_license_compatible(bom, dep):
-            if dep.data.get('root') in known_conflicts:
-                continue
-
             license_conflict_templ = "The license '{}' may be incompatible with the license '{}' in '{}'."
             msg = license_conflict_templ.format(license_id, dep_license_id, dep.root_dir)
             msg += " Specify 'copyright-holders' and/or 'licensees' to state the license is authorized in this context."

--- a/codebom/analyze.py
+++ b/codebom/analyze.py
@@ -1,0 +1,35 @@
+from .bom import BomError, get_item_position, get_file_position
+from .licenseconflict import is_dependent_license_compatible
+
+def collect_license_warnings(bom, is_source_dist):
+    warnings = []
+    license_id = bom.license or 'Unknown'
+
+    known_conflicts = bom.potential_license_conflicts
+    deps = is_source_dist and bom.all_dependencies or bom.dependencies
+    for dep in deps:
+        warnings += collect_license_warnings(dep, is_source_dist)
+
+        dep_license_id = dep.license or 'Unknown'
+        if not is_dependent_license_compatible(bom, dep):
+            if dep.data.get('root') in known_conflicts:
+                continue
+
+            license_conflict_templ = "The license '{}' may be incompatible with the license '{}' in '{}'."
+            msg = license_conflict_templ.format(license_id, dep_license_id, dep.root_dir)
+            msg += " Specify 'copyright-holders' and/or 'licensees' to state the license is authorized in this context."
+            if not is_source_dist:
+                msg += " If this dependency is used only for development, move it to the 'development-dependencies' section."
+            warnings.append(msg)
+    return warnings
+
+def add_source_position(msg, pos):
+    return "{}:{}:{}: {}".format(pos.src, pos.line, pos.col, msg) if pos else msg
+
+def analyze_bom(bom, **kwargs):
+    """
+    The textual counterpart to the graph command.
+    """
+    warnings = collect_license_warnings(bom, kwargs.get('is_source_dist'))
+    pos = 'license' in bom.data and bom.get_value_position('license') or get_file_position(bom.data)
+    return [add_source_position(msg, pos) for msg in warnings]

--- a/codebom/analyze_test.py
+++ b/codebom/analyze_test.py
@@ -1,0 +1,61 @@
+from . import analyze
+from .bom import Bom, SourcePosition
+
+def test_collect_license_warnings():
+    def license_warnings(data, is_source_dist=False):
+        return analyze.collect_license_warnings(Bom(data, '.'), is_source_dist)
+
+    data = {
+        'license': 'AllRightsReserved',
+        'dependencies': [{'root': 'foss', 'license': 'GPL-3.0'}]
+    }
+    assert license_warnings(data) == ["The license 'AllRightsReserved' may be incompatible with the license 'GPL-3.0' in 'foss'. Specify 'copyright-holders' and/or 'licensees' to state the license is authorized in this context. If this dependency is used only for development, move it to the 'development-dependencies' section."]
+
+    # Declaring AllRightsReserved is not sufficient. Need copyright-holders too.
+    data = {
+        'license': 'AllRightsReserved',
+        'dependencies': [{'root': 'foss', 'license': 'AllRightsReserved'}]
+    }
+    assert license_warnings(data) == ["The license 'AllRightsReserved' may be incompatible with the license 'AllRightsReserved' in 'foss'. Specify 'copyright-holders' and/or 'licensees' to state the license is authorized in this context. If this dependency is used only for development, move it to the 'development-dependencies' section."]
+
+    # Use 'licensee' declaration if you are an authorized client.
+    data = {
+        'license': 'AllRightsReserved',
+        'copyright-holders': ['P', 'Q'],
+        'dependencies': [{'root': 'foss', 'license': 'GPL-3.0', 'licensees': ['Q', 'R']}]
+    }
+    assert license_warnings(data) == []
+
+    # Assume copyright-holder is an implicit licensee.
+    data = {
+        'license': 'AllRightsReserved',
+        'copyright-holders': ['Q'],
+        'dependencies': [{'root': 'foss', 'license': 'GPL-3.0', 'copyright-holders': ['Q']}]
+    }
+    assert license_warnings(data) == []
+
+    # Don't warn if conflict happens within a development dependency (unless
+    # verifying a source distribution).
+    data = {
+        'development-dependencies': [
+            {'license': 'AllRightsReserved', 'dependencies': [{'license': 'GPL-3.0'}]}
+        ]
+    }
+    assert license_warnings(data) == []
+
+    # Don't warn on known conflicts.
+    data = {
+        'license': 'AllRightsReserved',
+        'copyright-holders': ['Q'],
+        'potential-license-conflicts': ['foss'],
+        'dependencies': [{'root': 'foss', 'license': 'GPL-3.0'}]
+    }
+    assert license_warnings(data) == []
+
+def test_analyze_bom():
+    data = {
+        'license': 'AllRightsReserved',
+        'dependencies': [{'root': 'foss', 'license': 'GPL-3.0'}]
+    }
+    assert analyze.analyze_bom(Bom(data, '.')) == ["The license 'AllRightsReserved' may be incompatible with the license 'GPL-3.0' in 'foss'. Specify 'copyright-holders' and/or 'licensees' to state the license is authorized in this context. If this dependency is used only for development, move it to the 'development-dependencies' section."]
+

--- a/codebom/analyze_test.py
+++ b/codebom/analyze_test.py
@@ -43,15 +43,6 @@ def test_collect_license_warnings():
     }
     assert license_warnings(data) == []
 
-    # Don't warn on known conflicts.
-    data = {
-        'license': 'AllRightsReserved',
-        'copyright-holders': ['Q'],
-        'potential-license-conflicts': ['foss'],
-        'dependencies': [{'root': 'foss', 'license': 'GPL-3.0'}]
-    }
-    assert license_warnings(data) == []
-
 def test_analyze_bom():
     data = {
         'license': 'AllRightsReserved',

--- a/codebom/bom.py
+++ b/codebom/bom.py
@@ -76,10 +76,6 @@ class Bom(object):
         return self.data.get('license')
 
     @property
-    def potential_license_conflicts(self):
-        return self.data.get('potential-license-conflicts', [])
-
-    @property
     def root_matches_origin(self):
         return self.data.get('root-matches-origin')
 

--- a/codebom/parseargs.py
+++ b/codebom/parseargs.py
@@ -35,6 +35,10 @@ def parse_args(argv):
     verify_parser.add_argument('-o', metavar='FILE', default=sys.stdout, type=argparse.FileType('w'))
     verify_parser.add_argument('--check-origins', choices=['uri', 'contents'])
 
+    analyze_parser = subparsers.add_parser('analyze', help='Analyze license dependencies')
+    analyze_parser.add_argument('--source-distribution', action='store_true')
+    analyze_parser.add_argument('-o', metavar='FILE', default=sys.stdout, type=argparse.FileType('wb'))
+
     graph_parser = subparsers.add_parser('graph', help='Graph license dependencies')
     graph_parser.add_argument('--source-distribution', action='store_true')
     graph_parser.add_argument('-o', metavar='FILE', default=sys.stdout, type=argparse.FileType('wb'))

--- a/codebom/verify.py
+++ b/codebom/verify.py
@@ -2,7 +2,6 @@ from urllib.parse import urlparse
 from urllib.request import urlretrieve
 from urllib.request import urlopen
 from .bom import BomError, get_item_position, get_file_position
-from .licenseconflict import is_dependent_license_compatible
 from .licenseidentifier import identify_license
 from .licenses import license_ids
 from ruamel.yaml.comments import CommentedMap
@@ -41,20 +40,6 @@ def collect_license_warnings(bom, is_source_dist, all_license_ids=license_ids):
         if warning:
             warnings.append(warning)
 
-    known_conflicts = bom.potential_license_conflicts
-    deps = is_source_dist and bom.all_dependencies or bom.dependencies
-    for dep in deps:
-        dep_license_id = dep.license or 'Unknown'
-        if not is_dependent_license_compatible(bom, dep):
-            if dep.data.get('root') in known_conflicts:
-                continue
-
-            license_conflict_templ = "The license '{}' may be incompatible with the license '{}' in '{}'."
-            msg = license_conflict_templ.format(license_id, dep_license_id, dep.root_dir)
-            msg += " Specify 'copyright-holders' and/or 'licensees' to state the license is authorized in this context."
-            if not is_source_dist:
-                msg += " If this dependency is used only for development, move it to the 'development-dependencies' section."
-            warnings.append(msg)
     return warnings
 
 def warn(msg, pos):

--- a/codebom/verify.py
+++ b/codebom/verify.py
@@ -136,7 +136,7 @@ def _verify_field(field_name, bom, parent_base_dir, verified_data, **kwargs):
         verified_data[field_name] = val
     elif field_name == 'license' and val != None:
         verified_data[field_name] = val
-    elif val and field_name in ['files', 'licensees', 'copyright-holders', 'potential-license-conflicts']:
+    elif val and field_name in ['files', 'licensees', 'copyright-holders']:
         verified_data[field_name] = val
     elif field_name == 'origin':
         check_origins = kwargs.get('check_origins')

--- a/codebom/verify_test.py
+++ b/codebom/verify_test.py
@@ -154,12 +154,6 @@ def test_verify_bom_license_conflict(capsys):
     assert out.msg.startswith('License file')
 
 def test_verify_bom_output():
-    data = {'licensees': ['Q'], 'potential-license-conflicts': ['foo']}
-    assert verify.verify_bom(Bom(data, '.'), '.') == data
-
-    data = {'licensees': [], 'potential-license-conflicts': []}
-    assert verify.verify_bom(Bom(data, '.'), '.') == {}
-
     data = {'name': 'foo'}
     assert verify.verify_bom(Bom(data, '.'), '.') == data
 


### PR DESCRIPTION
Long overdue splitting up of the `verify` command. The new `analyze` command does conflict detection. It is the textual counterpart to the `graph` command.